### PR TITLE
`action` misspelled

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -5,4 +5,5 @@ metadata
 # Temporary until logstash_stack is in community
 cookbook 'logstash_stack', git: 'git@github.com:rackspace-cookbooks/logstash_stack.git'
 cookbook 'rackspace_iptables', git: 'git@github.com:rackspace-cookbooks/rackspace_iptables.git'
+cookbook 'rackspace_cloudbackup', git: 'git@github.com:rackspace-cookbooks/rackspace_cloudbackup.git'
 cookbook 'cron', git: 'git@github.com:rackspace-cookbooks/cron.git'

--- a/recipes/locale.rb
+++ b/recipes/locale.rb
@@ -35,6 +35,6 @@ when 'redhat', 'centos'
     variables(
       cookbook_name: cookbook_name
     )
-    actoin 'create'
+    action 'create'
   end
 end


### PR DESCRIPTION
I did not get a chance to run this entirely through `test-kitchen`. There are
other errors in testing that are preventing me from testing this. This needs
to be cleaned up, but I need to move quicker.
