### PR TITLE
- Adding cloud_backup attributes

### DIFF
--- a/attributes/backup.rb
+++ b/attributes/backup.rb
@@ -1,1 +1,0 @@
-default['rackspace']['cloudbackup']['enabled'] = true

--- a/attributes/cloud_backup.rb
+++ b/attributes/cloud_backup.rb
@@ -1,0 +1,1 @@
+default['platformstack']['cloud_backup']['enabled'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -49,7 +49,7 @@ ruby_block 'platformstack' do
     unless node['newrelic']['license'].nil?
       run_context.include_recipe('platformstack::newrelic')
     end
-    if node['rackspace']['cloudbackup']['enabled'] == true
+    if node['platformstack']['cloud_backup']['enabled'] == true
       run_context.include_recipe('rackspace_cloudbackup')
     end
     if node['platformstack']['cloud_monitoring']['enabled'] == true


### PR DESCRIPTION
- Change cloud_backup attribute in recipes/default.rb in order to include recipe rackspace_cloudbackup
