### PR TITLE
Pass ruby code as ruby block

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 description 'Provides a full Tomcat stack'
 
-version '0.2.1'
+version '0.2.2'
 
 depends 'apt'
 depends 'auto-patch'

--- a/recipes/monitors.rb
+++ b/recipes/monitors.rb
@@ -47,7 +47,7 @@ execute 'agent-setup' do
   command "rackspace-monitoring-agent --setup --username #{node['rackspace']['cloud_credentials']['username']} --apikey #{node['rackspace']['cloud_credentials']['api_key']}"
   creates '/etc/rackspace-monitoring-agent.cfg'
   action :run
-  only_if node['platformstack']['cloud_monitoring']['enabled'] == true && File.size?('/etc/rackspace-monitoring-agent.cfg').nil?
+  only_if { node['platformstack']['cloud_monitoring']['enabled'] == true && File.size?('/etc/rackspace-monitoring-agent.cfg').nil? }
 end
 
 directory 'rackspace-monitoring-agent-confd' do


### PR DESCRIPTION
When using ruby code in an `only_if` or a `not_if`, it has to be passed as a
ruby block, or it will be run in a shellout on the node.
