### PR TITLE
Guard the monitoring agent with the enabled flag

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 description 'Provides a full Tomcat stack'
 
-version '0.2.2'
+version '0.2.3'
 
 depends 'apt'
 depends 'auto-patch'

--- a/recipes/monitors.rb
+++ b/recipes/monitors.rb
@@ -84,4 +84,5 @@ end
 service 'rackspace-monitoring-agent' do
   supports start: true, status: true, stop: true, restart: true
   action %w(enable start)
+  only_if { node['platformstack']['cloud_monitoring']['enabled'] == true }
 end


### PR DESCRIPTION
This will prevent the agent from enabling, starting, or restarting, regardless of what the individual stacks do in terms of templates or notifications to the resource.
