### PR TITLE
Install monitoring agent package, bump version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 description 'Provides a full Tomcat stack'
 
-version '0.2.3'
+version '0.2.4'
 
 depends 'apt'
 depends 'auto-patch'

--- a/recipes/monitors.rb
+++ b/recipes/monitors.rb
@@ -40,6 +40,7 @@ when 'rhel'
 end
 
 if node['platformstack']['cloud_monitoring']['enabled'] == true && File.size?('/etc/rackspace-monitoring-agent.cfg').nil?
+  package 'rackspace-monitoring-agent'
   if node.key?('cloud')
     execute 'agent-setup-cloud' do
       command "rackspace-monitoring-agent --setup --username #{node['rackspace']['cloud_credentials']['username']} --apikey #{node['rackspace']['cloud_credentials']['api_key']}"


### PR DESCRIPTION
The monitoring agent package was not installed by platformstack, which led to this error on attempts to restart the service:

service[rackspace-monitoring-agent]: unable to locate the init.d script!
