### PR TITLE
Monitoring improvements

### DIFF
--- a/attributes/cloud_monitoring.rb
+++ b/attributes/cloud_monitoring.rb
@@ -62,5 +62,13 @@ default['platformstack']['cloud_monitoring']['network']['recv']['warn'] = '56000
 default['platformstack']['cloud_monitoring']['network']['send']['crit'] = '76000'
 default['platformstack']['cloud_monitoring']['network']['send']['warn'] = '56000'
 
+# Currently for service monitoring, the recipe that sets up the service should add:
+# node.default['platformstack']['cloud_monitoring']['service']['name'].push('<service_name>')
+default['1936358-4info']['cloud_monitoring']['service']['name']         = []
+default['1936358-4info']['cloud_monitoring']['service']['disabled']     = false
+default['1936358-4info']['cloud_monitoring']['service']['alarm']        = false
+default['1936358-4info']['cloud_monitoring']['service']['period']       = 60
+default['1936358-4info']['cloud_monitoring']['service']['timeout']      = 30
+
 default['platformstack']['cloud_monitoring']['enabled'] = true
 default['platformstack']['cloud_monitoring']['notification_plan_id'] = 'npTechnicalContactsEmail'

--- a/attributes/cloud_monitoring.rb
+++ b/attributes/cloud_monitoring.rb
@@ -29,9 +29,14 @@ default['platformstack']['cloud_monitoring']['filesystem']['disabled'] = false
 default['platformstack']['cloud_monitoring']['filesystem']['alarm'] = false
 default['platformstack']['cloud_monitoring']['filesystem']['period'] = 60
 default['platformstack']['cloud_monitoring']['filesystem']['timeout'] = 30
-default['platformstack']['cloud_monitoring']['filesystem']['target'] = '/'
 default['platformstack']['cloud_monitoring']['filesystem']['crit'] = 90
 default['platformstack']['cloud_monitoring']['filesystem']['warn'] = 80
+
+node['filesystem'].each do |key, data|
+  unless data['percent_used'].nil? or data['fs_type'] == 'tmpfs'
+    default['platformstack']['cloud_monitoring']['filesystem']['target'][key] = data['mount']
+  end
+end
 
 default['platformstack']['cloud_monitoring']['load']['disabled'] = false
 default['platformstack']['cloud_monitoring']['load']['alarm'] = false

--- a/attributes/cloud_monitoring.rb
+++ b/attributes/cloud_monitoring.rb
@@ -34,8 +34,7 @@ default['platformstack']['cloud_monitoring']['filesystem']['warn'] = 80
 
 node['filesystem'].each do |key, data|
   next unless data['percent_used'].nil? || data['fs_type'] == 'tmpfs'
-    default['platformstack']['cloud_monitoring']['filesystem']['target'][key] = data['mount']
-  end
+  default['platformstack']['cloud_monitoring']['filesystem']['target'][key] = data['mount']
 end
 
 default['platformstack']['cloud_monitoring']['load']['disabled'] = false

--- a/attributes/cloud_monitoring.rb
+++ b/attributes/cloud_monitoring.rb
@@ -63,11 +63,11 @@ default['platformstack']['cloud_monitoring']['network']['send']['warn'] = '56000
 
 # Currently for service monitoring, the recipe that sets up the service should add:
 # node.default['platformstack']['cloud_monitoring']['service']['name'].push('<service_name>')
-default['1936358-4info']['cloud_monitoring']['service']['name']         = []
-default['1936358-4info']['cloud_monitoring']['service']['disabled']     = false
-default['1936358-4info']['cloud_monitoring']['service']['alarm']        = false
-default['1936358-4info']['cloud_monitoring']['service']['period']       = 60
-default['1936358-4info']['cloud_monitoring']['service']['timeout']      = 30
+default['platformstack']['cloud_monitoring']['service']['name']         = []
+default['platformstack']['cloud_monitoring']['service']['disabled']     = false
+default['platformstack']['cloud_monitoring']['service']['alarm']        = false
+default['platformstack']['cloud_monitoring']['service']['period']       = 60
+default['platformstack']['cloud_monitoring']['service']['timeout']      = 30
 
 default['platformstack']['cloud_monitoring']['enabled'] = true
 default['platformstack']['cloud_monitoring']['notification_plan_id'] = 'npTechnicalContactsEmail'

--- a/attributes/cloud_monitoring.rb
+++ b/attributes/cloud_monitoring.rb
@@ -1,3 +1,15 @@
+#
+# Cookbook Name:: platformstack
+# Attributes:: cloud_monitoring
+#
+# Copyright (C) 2014 Rackspace
+# 
+# All rights reserved - Do Not Redistribute
+#
+
+warn_load_threshold = node['cpu']['total'] * 2
+crit_load_threshold = node['cpu']['total'] * 3
+
 default['platformstack']['cloud_monitoring']['cpu']['disabled'] = false
 default['platformstack']['cloud_monitoring']['cpu']['alarm'] = false
 default['platformstack']['cloud_monitoring']['cpu']['period'] = 90
@@ -25,8 +37,8 @@ default['platformstack']['cloud_monitoring']['load']['disabled'] = false
 default['platformstack']['cloud_monitoring']['load']['alarm'] = false
 default['platformstack']['cloud_monitoring']['load']['period'] = 60
 default['platformstack']['cloud_monitoring']['load']['timeout'] = 30
-default['platformstack']['cloud_monitoring']['load']['crit'] = 3
-default['platformstack']['cloud_monitoring']['load']['warn'] = 2
+default['platformstack']['cloud_monitoring']['load']['crit'] = crit_load_threshold
+default['platformstack']['cloud_monitoring']['load']['warn'] = warn_load_threshold
 
 default['platformstack']['cloud_monitoring']['memory']['disabled'] = false
 default['platformstack']['cloud_monitoring']['memory']['alarm'] = false

--- a/attributes/cloud_monitoring.rb
+++ b/attributes/cloud_monitoring.rb
@@ -3,7 +3,7 @@
 # Attributes:: cloud_monitoring
 #
 # Copyright (C) 2014 Rackspace
-# 
+#
 # All rights reserved - Do Not Redistribute
 #
 
@@ -33,7 +33,7 @@ default['platformstack']['cloud_monitoring']['filesystem']['crit'] = 90
 default['platformstack']['cloud_monitoring']['filesystem']['warn'] = 80
 
 node['filesystem'].each do |key, data|
-  unless data['percent_used'].nil? or data['fs_type'] == 'tmpfs'
+  next unless data['percent_used'].nil? || data['fs_type'] == 'tmpfs'
     default['platformstack']['cloud_monitoring']['filesystem']['target'][key] = data['mount']
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 description 'Provides a full Tomcat stack'
 
-version '0.2.4'
+version '0.3.0'
 
 depends 'apt'
 depends 'auto-patch'

--- a/recipes/monitors.rb
+++ b/recipes/monitors.rb
@@ -119,8 +119,8 @@ unless node['platformstack']['cloud_monitoring']['service']['name'].empty?
   end
 end
 
-node['platformstack']['cloud_monitoring']['filesystem']['target'].each do |disk, mount|
-  template "/etc/rackspace-monitoring-agent.conf.d/monitoring-filesystem-#{mount.gsub('/','_slash_')}.yaml" do
+node['platformstack']['cloud_monitoring']['filesystem']['target'].each do |_disk, mount|
+  template "/etc/rackspace-monitoring-agent.conf.d/monitoring-filesystem-#{mount.gsub('/', '_slash_')}.yaml" do
     source 'monitoring-filesystem.erb'
     owner 'root'
     group 'root'

--- a/recipes/monitors.rb
+++ b/recipes/monitors.rb
@@ -39,19 +39,19 @@ when 'rhel'
   end
 end
 
-if node['platformstack']['cloud_monitoring']['enabled'] == true && File.size?('/etc/rackspace-monitoring-agent.cfg').nil?
+if node['platformstack']['cloud_monitoring']['enabled'] == true
   package 'rackspace-monitoring-agent'
   if node.key?('cloud')
     execute 'agent-setup-cloud' do
       command "rackspace-monitoring-agent --setup --username #{node['rackspace']['cloud_credentials']['username']} --apikey #{node['rackspace']['cloud_credentials']['api_key']}"
-      creates '/etc/rackspace-monitoring-agent.cfg'
       action 'nothing'
+      only_if { File.size?('/etc/rackspace-monitoring-agent.cfg').nil? }
     end
   else
     execute 'agent-setup-hybrid' do
       command "rackspace-monitoring-agent --setup --username #{node['rackspace']['hybrid_credentials']['username']} --apikey #{node['rackspace']['hybrid_credentials']['api_key']}"
-      creates '/etc/rackspace-monitoring-agent.cfg'
       action 'nothing'
+      only_if { File.size?('/etc/rackspace-monitoring-agent.cfg').nil? }
     end
   end
 end

--- a/recipes/monitors.rb
+++ b/recipes/monitors.rb
@@ -66,7 +66,6 @@ end
 yaml_monitors = %w(
   monitoring-cpu
   monitoring-disk
-  monitoring-filesystem
   monitoring-load
   monitoring-mem
   monitoring-net
@@ -84,6 +83,20 @@ yaml_monitors.each do |monitor|
     )
     only_if { node['platformstack']['cloud_monitoring']['enabled'] == true }
     notifies 'restart', 'service[rackspace-monitoring-agent]', 'delayed'
+  end
+end
+
+node['platformstack']['cloud_monitoring']['filesystem']['target'].each do |disk, mount|
+  template "/etc/rackspace-monitoring-agent.conf.d/monitoring-filesystem-#{mount.gsub('/','_slash_')}.yaml" do
+    source 'monitoring-filesystem.erb'
+    owner 'root'
+    group 'root'
+    mode '00644'
+    variables(
+      cookbook_name: cookbook_name,
+      mount: mount
+    )
+    notifies 'restart', 'service[rackspace-monitoring-agent]', :delayed
   end
 end
 

--- a/templates/default/monitoring-filesystem.erb
+++ b/templates/default/monitoring-filesystem.erb
@@ -3,16 +3,16 @@
 #
 
 type: agent.filesystem
-label: Filesystem check on <%= node['platformstack']['cloud_monitoring']['filesystem']['target'] %>
+label: Filesystem check on <%= @mount %>
 disabled: <%= node['platformstack']['cloud_monitoring']['filesystem']['disabled'] %>
 period: <%= node['platformstack']['cloud_monitoring']['filesystem']['period'] %>
 timeout: <%= node['platformstack']['cloud_monitoring']['filesystem']['timeout'] %>
 details:
-  target: <%= node['platformstack']['cloud_monitoring']['filesystem']['target'] %>
+  target: <%= @mount %>
 <% if node['platformstack']['cloud_monitoring']['filesystem']['alarm'] == true %>
 alarms:
     alarm-disk-size:
-        label: usage on <%= node['platformstack']['cloud_monitoring']['filesystem']['target'] %>
+        label: usage on <%= @mount %>
         notification_plan_id: <%= node['platformstack']['cloud_monitoring']['notification_plan_id'] %>
         criteria: |
             if (percentage(metric['used'], metric['total']) > <%= node['platformstack']['cloud_monitoring']['filesystem']['crit']  %> ) {
@@ -21,5 +21,5 @@ alarms:
             if (percentage(metric['used'], metric['total']) > <%= node['platformstack']['cloud_monitoring']['filesystem']['warn'] %> ) {
                 return new AlarmStatus(WARNING, 'Disk usage is above <%= node['platformstack']['cloud_monitoring']['filesystem']['warn'] %>%, #{used} out of #{total}');
             }
+            return new AlarmStatus(OK, 'Disk usage is below your warning threshold of <%= node['platformstack']['cloud_monitoring']['filesystem']['warn'] %>%, #{used} out of #{total}');
 <% end %>
-

--- a/templates/default/monitoring-load.erb
+++ b/templates/default/monitoring-load.erb
@@ -13,10 +13,10 @@ alarms:
         label: High Load Average
         notification_plan_id: <%= node['platformstack']['cloud_monitoring']['notification_plan_id'] %>
         criteria: |
-            if (metric['5m'] > <%= node['platformstack']['cloud_monitoring']['load']['crit'] %>
+            if (metric['5m'] > <%= node['platformstack']['cloud_monitoring']['load']['crit'] %> ) {
               return new AlarmStatus(CRITICAL, '5 minute load average is #{5m}, above your critical threshold of <%= node['platformstack']['cloud_monitoring']['load']['crit'] %>');
             }
-            if (metric['5m'] > <%= node['platformstack']['cloud_monitoring']['load']['warn'] %>
+            if (metric['5m'] > <%= node['platformstack']['cloud_monitoring']['load']['warn'] %> ) {
               return new AlarmStatus(WARNING, '5 minute load average is #{5m}, above your warning threshold of <%= node['platformstack']['cloud_monitoring']['load']['warn']  %>');
             }
             return new AlarmStatus(OK, '5 minute load average is #{5m}, below your warning threshold of <%= node['platformstack']['cloud_monitoring']['load']['warn']  %>');

--- a/templates/default/monitoring-service.erb
+++ b/templates/default/monitoring-service.erb
@@ -1,0 +1,24 @@
+# CHEF MANAGED FILE: DO NOT EDIT
+# Controlling Cookbook: <%= @cookbook_name %>
+#
+
+type: agent.plugin
+label: <%= @service_name %> Service Monitor
+disabled: <%= node['platformstack']['cloud_monitoring']['service']['disabled'] %>
+period: <%= node['platformstack']['cloud_monitoring']['service']['period'] %>
+timeout: <%= node['platformstack']['cloud_monitoring']['service']['timeout'] %>
+details:
+    file: service_mon.sh
+    args: [<%= @service_name %>]
+    timeout: 15000
+<% if node['platformstack']['cloud_monitoring']['service']['alarm'] == true %>
+alarms:
+    alarm-service:
+        label: <%= @service_name %> Service Running
+        notification_plan_id: npkUC0Xuuz
+        criteria: |
+            if (metric['status'] == 'CRITICAL') {
+              return new AlarmStatus(CRITICAL, 'Service <%= @service_name %> is NOT running');
+            }
+            return new AlarmStatus(OK, 'Service <%= @service_name %> is running');
+<% end %>

--- a/templates/default/service_mon.sh.erb
+++ b/templates/default/service_mon.sh.erb
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -z "$1" ]
+then
+  echo "USAGE: ./service_mon.sh <service>"
+fi
+
+service $1 status > /dev/null 2>&1
+ret=$?
+
+if [[ $ret != 0 ]]
+then
+  echo "status error: service $1 not running"
+  echo "metric status string CRITICAL"
+else
+  echo "status ok"
+  echo "metric status string OK"
+fi


### PR DESCRIPTION
--verbose is in commit messages (did some almost atomic level commits).

In general, dynamic load monitoring based on # of CPUs on target
Fix syntax error in monitoring-load
Dynamic Filesystem monitoring.  Will pick up any /dev filesystem in node['filesystems'] that is not a tmpfs
Added service monitoring.
Move only_if guard into agent-setup execution.  Fixes #60 
And bump minor version in metadata due to additional monitoring capabilities.
