### PR TITLE
Fix bad logic

### DIFF
--- a/attributes/cloud_monitoring.rb
+++ b/attributes/cloud_monitoring.rb
@@ -33,7 +33,7 @@ default['platformstack']['cloud_monitoring']['filesystem']['crit'] = 90
 default['platformstack']['cloud_monitoring']['filesystem']['warn'] = 80
 
 node['filesystem'].each do |key, data|
-  next unless data['percent_used'].nil? || data['fs_type'] == 'tmpfs'
+  next if data['percent_used'].nil? || data['fs_type'] == 'tmpfs'
   default['platformstack']['cloud_monitoring']['filesystem']['target'][key] = data['mount']
 end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 description 'Provides a full Tomcat stack'
 
-version '0.3.0'
+version '0.3.1'
 
 depends 'apt'
 depends 'auto-patch'


### PR DESCRIPTION
`next unless` is causing only items with tmpfs or percentage nil to be
added to the monitoring list. It's likely causing an issue where some
entries are missing percentage _and_ mount.
