### PR TITLE
Rakefile is failing, even while build passes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ group :lint do
   gem 'foodcritic', '~> 3.0'
   gem 'foodcritic-rackspace-rules', :git => 'git@github.com:AutomationSupport/foodcritic-rackspace-rules.git'
   gem 'rubocop', '~> 0.24'
+  gem 'rspec'
 end
 
 group :unit do


### PR DESCRIPTION
Currently, jenkins is failing to run rake:

```
Your bundle is complete!
Use `bundle show [gemname]` to see where a bundled gem is installed.
rake aborted!
LoadError: cannot load such file -- rspec/core/rake_task
/var/lib/jenkins/.rvm/gems/ruby-1.9.3-p547/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
/var/lib/jenkins/.rvm/gems/ruby-1.9.3-p547/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
/var/lib/jenkins/jobs/PlatformStack/workspace/Rakefile:32:in `<top (required)>'
/var/lib/jenkins/.rvm/gems/ruby-1.9.3-p547/bin/ruby_executable_hooks:15:in `eval'
/var/lib/jenkins/.rvm/gems/ruby-1.9.3-p547/bin/ruby_executable_hooks:15:in `<main>'
(See full trace by running task with --trace)
```
