### PR TITLE
attributes/cloud_monitoring.rb blows up if cloud monitoring toggle is turned off

### DIFF
--- a/attributes/cloud_monitoring.rb
+++ b/attributes/cloud_monitoring.rb
@@ -48,7 +48,10 @@ default['platformstack']['cloud_monitoring']['filesystem']['cookbook'] = 'platfo
 default['platformstack']['cloud_monitoring']['filesystem']['non_monitored_fstypes'] = %(tmpfs devtmpfs devpts proc mqueue cgroup efivars sysfs sys securityfs configfs fusectl)
 
 node['filesystem'].each do |key, data|
-  next if data['percent_used'].nil? || default['platformstack']['cloud_monitoring']['filesystem']['non_monitored_fstypes'].include?(data['fs_type'])
+  next if data['percent_used'].nil? || data['fs_type'].nil?
+  next if node['platformstack']['cloud_monitoring']['filesystem']['non_monitored_fstypes'].nil?
+  next if node['platformstack']['cloud_monitoring']['filesystem']['non_monitored_fstypes'].include?(data['fs_type'])
+  
   default['platformstack']['cloud_monitoring']['filesystem']['target'][key] = data['mount']
 end
 


### PR DESCRIPTION
There's `can't convert nil into String` when we turn off cloud monitoring using `node['platformstack']'cloud_monitoring']['enabled']=false`, due to this in attributes/cloud_monitoring.rb:

```
        50:  node['filesystem'].each do |key, data|
        51>>   next if data['percent_used'].nil? || default['platformstack']['cloud_monitoring']['filesystem']['non_monitored_fstypes'].include?(data['fs_type'])
        52:    default['platformstack']['cloud_monitoring']['filesystem']['target'][key] = data['mount']
        53:  end
```
