### PR TITLE
Moved newrelic recipe out of the ruby block 

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,7 +43,6 @@ ruby_block 'platformstack' do # ~FC014
       run_context.include_recipe('chef-client')
     end
     run_context.include_recipe('postfix') if node['platformstack']['postfix']['enabled'] == true
-    run_context.include_recipe('newrelic::default') unless node['newrelic']['license'].nil?
     run_context.include_recipe('rackspace_cloudbackup') if node['platformstack']['cloud_backup']['enabled'] == true
     run_context.include_recipe('statsd') if node['platformstack']['statsd']['enabled'] == true
     run_context.include_recipe('logstash_stack::rsyslog_client') if node['platformstack']['logstash_rsyslog']['enabled'] == true
@@ -56,3 +55,5 @@ ruby_block 'platformstack' do # ~FC014
     run_context.include_recipe('openssh')
   end
 end
+
+include_recipe('newrelic::default') unless node['newrelic']['license'].nil?


### PR DESCRIPTION
It was breaking the newrelic recipe (failing to install a package because include newrelic::repository was not working).
http://pastebin.com/pyMBurNv

I can definitely reproduce the issue when I'm integrating Pythonstack::newrelic=>platformstack::default.

I ran kitchen after this change : 

```
 |2.0.0-p481| MN4G0JG3QC in ~/chef/platformstack
→ kitchen list
Instance             Driver   Provisioner  Last Action
default-ubuntu-1204  Vagrant  ChefZero     Verified
default-centos-65    Vagrant  ChefZero     Verified
```

I don't think it is useful to put newrelic inside the rubyblock. So it should be fine.
