### PR TITLE
Adding a validation to make chef-client runs as upstart service

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,3 +20,8 @@
 
 default['rackspace']['cloud_credentials']['username'] = nil
 default['rackspace']['cloud_credentials']['api_key'] = nil
+
+case node['platform_family']
+when 'debian'
+  default['chef_client']['init_style'] = 'upstart'
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,10 +1,10 @@
 name 'platformstack'
-maintainer 'Rackspace US, Inc.'
+maintainer 'Rackspace'
 maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 description 'Provides a full Tomcat stack'
 
-version '1.1.2'
+version '1.1.3'
 
 %w(ubuntu debian redhat centos).each do |os|
   supports os


### PR DESCRIPTION
When debian platform_family set attribute default['chef_client']['init_style'] = 'upstart'
