### PR TITLE
Support LXC/Docker, for testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# builds docker container to be used with CI
+
+FROM paulczar/meez
+
+ADD Gemfile /tmp/Gemfile
+
+ENV PATH /opt/chefdk/embedded/bin:/root/.chefdk/gem/ruby/2.1.0/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV USE_SYSTEM_GECODE 1
+
+RUN cd /tmp && bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,12 @@ end
 group :kitchen_common do
   gem 'test-kitchen'
   gem 'kitchen-rackspace'
+  gem 'kitchen-docker'
 end
 
 group :kitchen_vagrant do
   gem 'kitchen-vagrant'
+  gem 'vagrant-wrapper'
 end
 
 group :development do

--- a/recipes/iptables.rb
+++ b/recipes/iptables.rb
@@ -20,7 +20,7 @@
 #
 include_recipe 'chef-sugar'
 
-unless node.deep_fetch('virtualization', 'systems', 'lxc') == 'guest'
+unless node['virtualization'] && node['virtualization']['system'] == 'lxc'
   if node['platformstack']['rackconnect'] == true
     sudo 'rackconnect' do
       user 'rackconnect'

--- a/recipes/locale.rb
+++ b/recipes/locale.rb
@@ -26,7 +26,7 @@ when 'debian'
     command "/usr/sbin/update-locale LANG=#{node['platformstack']['locale']}"
     user 'root'
     action 'run'
-    not_if { node.deep_fetch('virtualization', 'systems', 'lxc') == 'guest' }
+    not_if { node['virtualization'] && node['virtualization']['system'] == 'lxc' }
   end
 when 'redhat'
   template '/etc/sysconfig/i18n' do
@@ -38,6 +38,6 @@ when 'redhat'
       cookbook_name: cookbook_name
     )
     action 'create'
-    not_if { node.deep_fetch('virtualization', 'systems', 'lxc') == 'guest' }
+    not_if { node['virtualization'] && node['virtualization']['system'] == 'lxc' }
   end
 end


### PR DESCRIPTION
Would need to resolve https://github.com/sethvargo/chef-sugar/issues/60 and/or https://github.com/rackerlabs/ohai-plugins/issues/121. These would let us do guards like `node.lxc?` based on the values inside `node['virtualization']`, but they are currently not being populated.
