### PR TITLE
Cannot supply additional monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Sets up monitoring for the following by default:
 - service
  - only enabled if set up via the `node['platformstack']['cloud_monitoring']['service']['name']` attribute
 
-You can set the period and timeout along with the critical and warning thresholds via attributes, check the cloud_monitoring attributes file for more info.
+You can set the period and timeout along with the critical and warning thresholds via attributes, as well as configure custom monitors. Check the cloud_monitoring attributes file for more info.
 
 #### default
 Sets the timezone to UTC by default.

--- a/attributes/cloud_monitoring.rb
+++ b/attributes/cloud_monitoring.rb
@@ -84,6 +84,7 @@ default['platformstack']['cloud_monitoring']['network']['send']['crit'] = '76000
 default['platformstack']['cloud_monitoring']['network']['send']['warn'] = '56000'
 default['platformstack']['cloud_monitoring']['network']['cookbook'] = 'platformstack'
 
+# NOTE: this is for 'service monitoring' using service_mon.sh. go to the next section for arbitrary monitors.
 # Currently for service monitoring, the recipe that sets up the service should add:
 # node.default['platformstack']['cloud_monitoring']['service']['name'].push('<service_name>')
 default['platformstack']['cloud_monitoring']['service']['name']         = []
@@ -93,6 +94,15 @@ default['platformstack']['cloud_monitoring']['service']['period']       = 60
 default['platformstack']['cloud_monitoring']['service']['timeout']      = 30
 default['platformstack']['cloud_monitoring']['service']['cookbook'] = 'platformstack'
 default['platformstack']['cloud_monitoring']['service_mon']['cookbook'] = 'platformstack'
+
+# arbitrary / non-service-monitors data structure for any arbitrary template
+default['platformstack']['cloud_monitoring']['custom_monitors']['name']         = []
+# Currently for arbitrary monitoring, the recipe that sets up the monitor should add:
+# node.default['platformstack']['cloud_monitoring']['custom_monitors']['name'].push('<service_name>')
+# and then populate node['platformstack']['cloud_monitoring'][service_name][setting] with your values
+# default['platformstack']['cloud_monitoring']['custom_monitors'][<name>]['source'] = 'my_monitor.yaml.erb'
+# default['platformstack']['cloud_monitoring']['custom_monitors'][<name>]['cookbook'] = 'your_cookbook'
+# default['platformstack']['cloud_monitoring']['custom_monitors'][<name>]['variables'] = { :warning => 'foo' }
 
 default['platformstack']['cloud_monitoring']['plugins'] = {}
 # Generic plugin support. Requires hash like:

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 description 'Provides Rackspace managed support beyond rackops_rolebook'
 
-version '1.2.2'
+version '1.3.0'
 
 %w(ubuntu debian redhat centos).each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -55,7 +55,6 @@ ruby_block 'platformstack' do # ~FC014
     run_context.include_recipe('omnibus_updater') if node['platformstack']['omnibus_updater']['enabled'] == true
     run_context.include_recipe('consul::install_binary') if node['platformstack']['consul']['enabled'] == true
     run_context.include_recipe('platformstack::monitors')
-    run_context.include_recipe('platformstack::logging')
     # run this last because if feels so good
     run_context.include_recipe('platformstack::iptables')
     # down here because iptables sets an attribute for openssh if it's rackconnected
@@ -64,3 +63,4 @@ ruby_block 'platformstack' do # ~FC014
 end
 
 include_recipe('newrelic::default') unless node['newrelic']['license'].nil?
+include_recipe('platformstack::logging')

--- a/recipes/logging.rb
+++ b/recipes/logging.rb
@@ -18,7 +18,7 @@ if Chef::Config[:solo]
 else
   include_recipe 'elasticsearch::search_discovery'
 end
-elk_nodes = node['elasticsearch']['discovery']['zen']['ping']['unicast']['hosts']
+elk_nodes = node.deep_fetch('elasticsearch', 'discovery', 'zen', 'ping', 'unicast', 'hosts')
 found_elkstack = !elk_nodes.nil? && !elk_nodes.split(',').empty? # don't do anything unless we find nodes
 
 return unless found_elkstack

--- a/recipes/monitors.rb
+++ b/recipes/monitors.rb
@@ -81,6 +81,24 @@ yaml_monitors.each do |monitor|
   end
 end
 
+# any custom monitors
+node['platformstack']['cloud_monitoring']['custom_monitors']['name'].each do |monitor|
+
+  monitor_source = node['platformstack']['cloud_monitoring']['custom_monitors'][monitor]['source']
+  monitor_cookbook = node['platformstack']['cloud_monitoring']['custom_monitors'][monitor]['cookbook']
+  monitor_variables = node['platformstack']['cloud_monitoring']['custom_monitors'][monitor]['variables']
+
+  template "/etc/rackspace-monitoring-agent.conf.d/monitoring-#{monitor}.yaml" do
+    cookbook monitor_cookbook
+    source monitor_source
+    owner 'root'
+    group 'root'
+    mode '00644'
+    variables(monitor_variables)
+    notifies 'restart', 'service[rackspace-monitoring-agent]', 'delayed'
+  end
+end
+
 unless node['platformstack']['cloud_monitoring']['service']['name'].empty?
   directory '/usr/lib/rackspace-monitoring-agent/plugins' do
     recursive true

--- a/test/unit/spec/monitors_spec.rb
+++ b/test/unit/spec/monitors_spec.rb
@@ -19,7 +19,7 @@ describe 'platformstack::monitors' do
             node.set['platformstack']['cloud_monitoring']['custom_monitors']['name'].push('chefspec-monitor')
             node.set['platformstack']['cloud_monitoring']['custom_monitors']['chefspec-monitor']['source'] = 'chefspec_monitor.yaml.erb'
             node.set['platformstack']['cloud_monitoring']['custom_monitors']['chefspec-monitor']['cookbook'] = 'chefspec_book'
-            node.set['platformstack']['cloud_monitoring']['custom_monitors']['chefspec-monitor']['variables'] = { :warning => 'foo' }
+            node.set['platformstack']['cloud_monitoring']['custom_monitors']['chefspec-monitor']['variables'] = { warning: 'foo' }
           end.converge(described_recipe)
         end
 
@@ -33,7 +33,6 @@ describe 'platformstack::monitors' do
         it 'creates templates for custom monitors' do
           expect(chef_run).to create_template('/etc/rackspace-monitoring-agent.conf.d/monitoring-chefspec-monitor.yaml')
         end
-
 
         it 'creates templates for specific monitors' do
           expect(chef_run).to create_template('/etc/rackspace-monitoring-agent.conf.d/monitoring-cpu.yaml')


### PR DESCRIPTION
From `attributes/cloud_monitoring.rb`:

```
# Currently for service monitoring, the recipe that sets up the service should add:
# node.default['platformstack']['cloud_monitoring']['service']['name'].push('<service_name>')
default['platformstack']['cloud_monitoring']['service']['name'] = []
default['platformstack']['cloud_monitoring']['service']['disabled'] = false
default['platformstack']['cloud_monitoring']['service']['alarm'] = false
default['platformstack']['cloud_monitoring']['service']['period'] = 60
default['platformstack']['cloud_monitoring']['service']['timeout'] = 30
default['platformstack']['cloud_monitoring']['service']['cookbook'] = 'platformstack'
default['platformstack']['cloud_monitoring']['service_mon']['cookbook'] = 'platformstack'
```

This only configures monitors using an existing `service_mon.sh` template. There is no way to configure a custom template.
