### PR TITLE
Don't converge elkstack* until we find servers

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'rackspace-cookbooks@rackspace.com'
 license 'Apache 2.0'
 description 'Provides Rackspace managed support beyond rackops_rolebook'
 
-version '1.4.1'
+version '1.4.2'
 
 %w(ubuntu debian redhat centos).each do |os|
   supports os

--- a/recipes/logging.rb
+++ b/recipes/logging.rb
@@ -10,7 +10,18 @@ include_recipe 'chef-sugar'
 # This recipe *must* guard everything with node['platformstack']['elkstack_logging']['enabled']
 enable_attr = node.deep_fetch('platformstack', 'elkstack_logging', 'enabled')
 logging_enabled = !enable_attr.nil? && enable_attr # ensure this is binary logic, not nil
-return unless logging_enabled
+Chef::Log.info("Logging with ELK stack has enabled value of #{logging_enabled}")
+
+# find central servers, if any
+if Chef::Config[:solo]
+  Chef::Log.warn('Cannot invoke search for ELK cluster while running under chef-solo')
+else
+  include_recipe 'elasticsearch::search_discovery'
+end
+elk_nodes = node.deep_fetch('elasticsearch', 'discovery', 'zen', 'ping', 'unicast', 'hosts')
+found_elkstack = !elk_nodes.nil? && !elk_nodes.split(',').empty? # don't do anything unless we find nodes
+
+return unless logging_enabled && found_elkstack
 Chef::Log.warn('Will be configuring this node to log against elkstack nodes')
 
 # configure runlist


### PR DESCRIPTION
Undo part of https://github.com/rackspace-cookbooks/platformstack/commit/8d156fd9f918b4a5050a9e19bac8b3ba0dcc23c6#diff-51f1680bd56ca6568162c7afe940095d so we don't do too much elkstack before we actually can use it
