### PR TITLE
Do not run platformstack::monitors if not required

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -52,7 +52,7 @@ ruby_block 'platformstack' do # ~FC014
     run_context.include_recipe('slack_handler') if node['platformstack']['slack_handler']['enabled'] == true
     run_context.include_recipe('omnibus_updater') if node['platformstack']['omnibus_updater']['enabled'] == true
     run_context.include_recipe('consul::install_binary') if node['platformstack']['consul']['enabled'] == true
-    run_context.include_recipe('platformstack::monitors')
+    run_context.include_recipe('platformstack::monitors') if node['platformstack']['cloud_monitoring']['enabled'] == true
     # run this last because if feels so good
     run_context.include_recipe('platformstack::iptables') if node['platformstack']['iptables']['enabled'] == true
     # down here because iptables sets an attribute for openssh if it's rackconnected

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -9,25 +9,71 @@ describe 'platformstack::default' do
   supported_platforms.each do |platform, versions|
     versions.each do |version|
       context "on #{platform.capitalize} #{version}" do
-        let(:chef_run) do
-          ChefSpec::SoloRunner.new(platform: platform, version: version) do |node|
-            node_resources(node)
-          end.converge(described_recipe)
+        context 'when everything is enabled' do
+          let(:chef_run) do
+            # step_into the ruby block so we can test recipe includes
+            ChefSpec::SoloRunner.new(platform: platform, version: version, step_into: ['ruby_block']) do |node|
+              node_resources(node)
+              node.set['platformstack']['postfix']['enabled'] = true
+              # Commented as it raises an error on Chefspec
+              # node.set['platformstack']['cloud_backup']['enabled'] = true
+              node.set['platformstack']['statsd']['enabled'] = true
+              node.set['platformstack']['logstash_rsyslog']['enabled'] = true
+              # rsyslog minimal configuration with chef-solo
+              node.set['rsyslog']['server_ip'] = '10.0.0.1'
+              # Commented as it raises an error on Chefspec(chef-solo)
+              # node.set['platformstack']['client_rekey']['enabled'] = true
+              node.set['platformstack']['slack_handler']['enabled'] = true
+              node.set['platformstack']['omnibus_updater']['enabled'] = true
+              node.set['platformstack']['consul']['enabled'] = true
+              node.set['platformstack']['cloud_monitoring']['enabled'] = true
+              node.set['platformstack']['iptables']['enabled'] = true
+            end.converge(described_recipe)
+          end
+
+          # we can use anything here to test it later
+          _property = load_platform_properties(platform: platform, platform_version: version)
+
+          it 'includes the ruby block recipes' do
+            %w(
+              postfix
+              statsd
+              rsyslog::client
+              slack_handler
+              omnibus_updater
+              consul::install_binary
+              platformstack::monitors
+              platformstack::iptables
+              openssh
+            ).each do |recipe|
+              expect(chef_run).to include_recipe(recipe)
+            end
+          end
+
+          it 'includes newrelic monitoring' do
+            expect(chef_run).to include_recipe('newrelic::default')
+          end
+
+          it 'creates log resource to run default stuff last' do
+            expect(chef_run).to write_log('run the default stuff last')
+          end
+
+          it 'creates ruby_block platformstack' do
+            expect(chef_run).to run_ruby_block('platformstack')
+          end
         end
-
-        # we can use anything here to test it later
-        _property = load_platform_properties(platform: platform, platform_version: version)
-
-        it 'includes newrelic monitoring' do
-          expect(chef_run).to include_recipe('newrelic::default')
-        end
-
-        it 'creates log resource to run default stuff last' do
-          expect(chef_run).to write_log('run the default stuff last')
-        end
-
-        it 'creates ruby_block platformstack' do
-          expect(chef_run).to run_ruby_block('platformstack')
+        context 'when cloud monitoring disabled' do
+          let(:chef_run) do
+            # step_into the ruby block so we can test recipe includes
+            ChefSpec::SoloRunner.new(platform: platform, version: version, step_into: ['ruby_block']) do |node|
+              node_resources(node)
+              # Manually disable cloud_monitoring
+              node.set['platformstack']['cloud_monitoring']['enabled'] = false
+            end.converge(described_recipe)
+          end
+          it "doesn't include cloud monitoring" do
+            expect(chef_run).to_not include_recipe('platformstack::monitors')
+          end
         end
       end
     end

--- a/test/unit/spec/spec_helper.rb
+++ b/test/unit/spec/spec_helper.rb
@@ -26,6 +26,8 @@ end
 
 def stub_resources
   stub_command('which sudo').and_return('/usr/bin/sudo')
+  stub_command('test -L /usr/local/bin/consul').and_return(true)
+  stub_command('/usr/bin/test /etc/alternatives/mta -ef /usr/sbin/sendmail.postfix').and_return(true)
 end
 
 at_exit { ChefSpec::Coverage.report! }


### PR DESCRIPTION
There is a flag to disable cloud-monitoring : `node['platformstack']['cloud_monitoring']['enabled']`
However it will only prevent the [install of the agent](https://github.com/rackspace-cookbooks/platformstack/blob/4a76ac67d8f17ae3a1cbde9e02e67aa1b92c25e5/recipes/monitors.rb#L42-L52), but it will still install ALL agent configuration.

With this change nothing about cloud-monitoring will be done if `node['platformstack']['cloud_monitoring']['enabled']` is set to false.

The ruby block `ruby_block 'platformstack'` was not tested before, it should be better with this PR.
