### PR TITLE
Change Chef actions to symbols

### DIFF
--- a/recipes/locale.rb
+++ b/recipes/locale.rb
@@ -25,7 +25,7 @@ when 'debian'
   execute 'fix_locale' do
     command "/usr/sbin/update-locale LANG=#{node['platformstack']['locale']}"
     user 'root'
-    action 'run'
+    action :run
     not_if { lxc? }
   end
 when 'rhel'
@@ -37,7 +37,7 @@ when 'rhel'
     variables(
       cookbook_name: cookbook_name
     )
-    action 'create'
+    action :create
     not_if { lxc? }
   end
 end

--- a/recipes/monitors.rb
+++ b/recipes/monitors.rb
@@ -44,7 +44,7 @@ if node['platformstack']['cloud_monitoring']['enabled'] == true
   if node.key?('cloud')
     execute 'agent-setup-cloud' do
       command "rackspace-monitoring-agent --setup --username #{node['rackspace']['cloud_credentials']['username']} --apikey #{node['rackspace']['cloud_credentials']['api_key']}"
-      action 'run'
+      action :run
       # the filesize is zero if the agent has not been configured
       only_if { File.size?('/etc/rackspace-monitoring-agent.cfg').nil? }
     end

--- a/recipes/public_info.rb
+++ b/recipes/public_info.rb
@@ -11,7 +11,7 @@ include_recipe 'chef-sugar'
 # ensure rest-client gem is available
 chef_gem 'rest-client' do
   action :nothing
-end.run_action('install')
+end.run_action(:install)
 
 # Load the ohai recipe to populate node['ohai']
 include_recipe 'ohai'
@@ -28,20 +28,20 @@ directory node['ohai']['plugin_path'] do
   group 'root'
   mode  '0755'
   recursive true
-  action 'nothing'
-end.run_action('create')
+  action :nothing
+end.run_action(:create)
 
 cookbook_file "#{node['ohai']['plugin_path']}/public_info.rb" do
   owner 'root'
   group 'root'
   mode  '0644'
-  action 'nothing'
-end.run_action('create')
+  action :nothing
+end.run_action(:create)
 
 ohai 'reload_pubinfo' do
   plugin 'public_info'
-  action 'nothing'
-end.run_action('reload')
+  action :nothing
+end.run_action(:reload)
 
 # Stop the run if the IP is invalid, assume failure here is preferable to running with invalid data
 # This check is also important for testing: if the plugin fails to load and operate this exception will

--- a/test/unit/spec/ohai_plugins_spec.rb
+++ b/test/unit/spec/ohai_plugins_spec.rb
@@ -26,7 +26,7 @@ describe 'platformstack::ohai_plugins' do
         end
 
         it 'reloads ohai' do
-          expect(chef_run).to reload_ohai('reload')
+          expect(chef_run).to reload_ohai(:reload)
         end
       end
     end


### PR DESCRIPTION
Per https://github.com/chef/chef/issues/3009, chef actions should never have been strings. They should always have been symbols.
