### PR TITLE
Remove rest-client installation as well

### DIFF
--- a/recipes/public_info.rb
+++ b/recipes/public_info.rb
@@ -8,11 +8,6 @@
 #
 include_recipe 'chef-sugar'
 
-# ensure rest-client gem is available
-chef_gem 'rest-client' do
-  action :nothing
-end.run_action(:install)
-
 # Load the ohai recipe to populate node['ohai']
 include_recipe 'ohai'
 

--- a/test/unit/spec/public_info_spec.rb
+++ b/test/unit/spec/public_info_spec.rb
@@ -17,10 +17,6 @@ describe 'platformstack::public_info' do
         # we can use anything here to test it later
         _property = load_platform_properties(platform: platform, platform_version: version)
 
-        it 'installs the rest-client gem' do
-          expect(chef_run).to install_chef_gem('rest-client')
-        end
-
         it 'creates the directory for ohai plugins' do
           expect(chef_run).to create_directory('/etc/chef/ohai_plugins')
         end


### PR DESCRIPTION
With https://github.com/rackspace-cookbooks/rackspace_cloudbackup/pull/23, we no longer need to install the gem here.
