### PR TITLE
Chef 12.1 for customers using point releases 1.5.x

### DIFF
--- a/recipes/locale.rb
+++ b/recipes/locale.rb
@@ -25,7 +25,7 @@ when 'debian'
   execute 'fix_locale' do
     command "/usr/sbin/update-locale LANG=#{node['platformstack']['locale']}"
     user 'root'
-    action 'run'
+    action :run
     not_if { lxc? }
   end
 when 'rhel'
@@ -37,7 +37,7 @@ when 'rhel'
     variables(
       cookbook_name: cookbook_name
     )
-    action 'create'
+    action :create
     not_if { lxc? }
   end
 end

--- a/recipes/monitors.rb
+++ b/recipes/monitors.rb
@@ -44,7 +44,7 @@ if node['platformstack']['cloud_monitoring']['enabled'] == true
   if node.key?('cloud')
     execute 'agent-setup-cloud' do
       command "rackspace-monitoring-agent --setup --username #{node['rackspace']['cloud_credentials']['username']} --apikey #{node['rackspace']['cloud_credentials']['api_key']}"
-      action 'run'
+      action :run
       # the filesize is zero if the agent has not been configured
       only_if { File.size?('/etc/rackspace-monitoring-agent.cfg').nil? }
     end
@@ -213,6 +213,6 @@ end
 
 service 'rackspace-monitoring-agent' do
   supports start: true, status: true, stop: true, restart: true
-  action %w(enable start)
+  action [:enable,:start]
   only_if { node['platformstack']['cloud_monitoring']['enabled'] == true }
 end


### PR DESCRIPTION
This change mirrors #188, but will be released as 1.5.4, so we can upgrade chef orgs to newer platformstack without moving to 2.x or 3.x.
