### PR TITLE
Chef 12.1 for customers using point releases 1.5.x

### DIFF
--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -1,0 +1,8 @@
+---
+driver:
+  name: rackspace
+  flavor_id: performance1-2
+  rackspace_region: IAD
+  require_chef_omnibus: latest
+  server_name: ci-<%= ENV['CIRCLE_PROJECT_REPONAME'] %>-<%= ENV['CIRCLE_BUILD_NUM'] %>-<%= require 'securerandom'; SecureRandom.hex(6) %>
+  wait_for: 1200

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 group :lint do
   gem 'foodcritic', '~> 3.0'
-  gem 'foodcritic-rackspace-rules', :git => 'git@github.com:AutomationSupport/foodcritic-rackspace-rules.git'
   gem 'rubocop', '~> 0.24'
   gem 'rspec'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -41,11 +41,21 @@ namespace :integration do
   task :cloud do
     if ENV['CI'] == 'true'
       Kitchen.logger = Kitchen.default_file_logger
-      @loader = Kitchen::Loader::YAML.new(local_config: '/var/lib/jenkins/.kitchen/config.yml')
+      @loader = Kitchen::Loader::YAML.new(local_config: '.kitchen.cloud.yml')
       config = Kitchen::Config.new(loader: @loader)
-      config.instances.each do |instance|
-        instance.test(:always)
+      concurrency = config.instances.size
+      queue = Queue.new
+      config.instances.each {|i| queue << i }
+      concurrency.times { queue << nil }
+      threads = []
+      concurrency.times do
+        threads << Thread.new do
+          while instance = queue.pop
+            instance.test(:always)
+          end
+        end
       end
+      threads.map { |i| i.join }
     end
   end
 end

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,23 @@
+machine:
+  ruby:
+    version: 2.1.5
+  environment:
+    KITCHEN_LOCAL_YAML: .kitchen.cloud.yml
+
+dependencies:
+  cache_directories:
+    - "~/bundle"
+  pre:
+    - ssh-keygen -y -f ~/.ssh/build_key.rsa > ~/.ssh/id_rsa.pub
+  override:
+    - bundle install --path=~/bundle --jobs=4 --retry=3:
+        timeout: 600
+
+test:
+  override:
+    - bundle exec rake style:
+        timeout: 120
+    - bundle exec rake spec:
+        timeout: 120
+    - bundle exec rake integration:cloud:
+        timeout: 600

--- a/recipes/locale.rb
+++ b/recipes/locale.rb
@@ -25,7 +25,7 @@ when 'debian'
   execute 'fix_locale' do
     command "/usr/sbin/update-locale LANG=#{node['platformstack']['locale']}"
     user 'root'
-    action 'run'
+    action :run
     not_if { lxc? }
   end
 when 'rhel'
@@ -37,7 +37,7 @@ when 'rhel'
     variables(
       cookbook_name: cookbook_name
     )
-    action 'create'
+    action :create
     not_if { lxc? }
   end
 end

--- a/recipes/monitors.rb
+++ b/recipes/monitors.rb
@@ -213,6 +213,6 @@ end
 
 service 'rackspace-monitoring-agent' do
   supports start: true, status: true, stop: true, restart: true
-  action [:enable,:start]
+  action [:enable, :start]
   only_if { node['platformstack']['cloud_monitoring']['enabled'] == true }
 end

--- a/recipes/monitors.rb
+++ b/recipes/monitors.rb
@@ -44,7 +44,7 @@ if node['platformstack']['cloud_monitoring']['enabled'] == true
   if node.key?('cloud')
     execute 'agent-setup-cloud' do
       command "rackspace-monitoring-agent --setup --username #{node['rackspace']['cloud_credentials']['username']} --apikey #{node['rackspace']['cloud_credentials']['api_key']}"
-      action 'run'
+      action :run
       # the filesize is zero if the agent has not been configured
       only_if { File.size?('/etc/rackspace-monitoring-agent.cfg').nil? }
     end
@@ -213,6 +213,6 @@ end
 
 service 'rackspace-monitoring-agent' do
   supports start: true, status: true, stop: true, restart: true
-  action %w(enable start)
+  action [:enable,:start]
   only_if { node['platformstack']['cloud_monitoring']['enabled'] == true }
 end


### PR DESCRIPTION
This change mirrors #188, but will be released as 1.5.4, so we can upgrade chef orgs to newer platformstack without moving to 2.x or 3.x.

I've created a maintenance branch that reflects our last release of v1.5.3 of platformstack. We should keep this branch around since it contains source (this commit below) that doesn't exist in the master branch, even though it mirrors PR #188 from the master branch.
