### PR TITLE
Remove Berksfile entries that aren't needed

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,7 +2,6 @@ metadata
 
 source "https://api.berkshelf.com"
 
-cookbook 'rackspace_cloudbackup', git: 'git@github.com:rackspace-cookbooks/rackspace_cloudbackup.git'
-cookbook 'cron', git: 'git@github.com:rackspace-cookbooks/cron.git'
-cookbook 'slack_handler', git:'git@github.com:rackspace-cookbooks/chef-slack_handler'
-
+# Please, think *very* hard about adding anything here. This is a dependency for
+# hundreds, if not thousands, of real chef orgs, as well as libraries and other
+# community cookbooks. You will break them *all* if you add an entry here.


### PR DESCRIPTION
We should avoid Berksfile entries entirely for platformstack. It could result in hundreds of downstream broken builds for stacks, libraries, and customers.
