### PR TITLE
Pin git cookbook back to avoid mysql cookbook bug

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,6 @@ depends 'chef-client'
 depends 'chef-sugar'
 depends 'client-rekey'
 depends 'consul'
-depends 'git'
 depends 'java'
 depends 'motd-tail', '~> 2.0'
 depends 'newrelic'
@@ -34,6 +33,9 @@ depends 'timezone-ii'
 depends 'user', '~> 0.3'
 depends 'yum'
 depends 'slack_handler'
+
+# until https://github.com/rackspace-cookbooks/platformstack/issues/198
+depends 'git', '= 4.1.0'
 
 # conflicts with any version @ 2.0.0 of this cookbook
 conflicts 'rackops_rolebook'


### PR DESCRIPTION
RE: https://github.com/rackspace-cookbooks/platformstack/issues/198, pin back git cookbook while we figure out a longer-term path forward.
