### PR TITLE
Revert git cookbook pinning

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -16,6 +16,7 @@ depends 'chef-client'
 depends 'chef-sugar'
 depends 'client-rekey'
 depends 'consul'
+depends 'git'
 depends 'java'
 depends 'motd-tail', '~> 2.0'
 depends 'newrelic'
@@ -33,9 +34,6 @@ depends 'timezone-ii'
 depends 'user', '~> 0.3'
 depends 'yum'
 depends 'slack_handler'
-
-# until https://github.com/rackspace-cookbooks/platformstack/issues/198
-depends 'git', '= 4.1.0'
 
 # conflicts with any version @ 2.0.0 of this cookbook
 conflicts 'rackops_rolebook'


### PR DESCRIPTION
This reverts commit f883aab7a2d634dacd83db7969aa76699c70e579. RE: https://github.com/rackspace-cookbooks/platformstack/pull/199.
