### PR TITLE
Adding missing packages

### DIFF
--- a/recipes/rackops_rolebook.rb
+++ b/recipes/rackops_rolebook.rb
@@ -36,6 +36,8 @@ admin_packages = %w(
   zip
   lsof
   strace
+  tmux
+  git
 )
 
 case node['platform_family']


### PR DESCRIPTION
With these missing packages added, `rackspace_support` and `platformstack` are now on par. :+1: 

Fixes: https://github.com/the-galley/rackspace_support/issues/3
