### PR TITLE
Don't pass false for NR license

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,4 +60,4 @@ ruby_block 'platformstack' do # ~FC014
   end
 end
 
-include_recipe('newrelic::default') unless node['newrelic']['license'].nil?
+include_recipe('newrelic::default') if node['newrelic']['license'] && !node['newrelic']['license'].blank?

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -50,6 +50,7 @@ describe 'platformstack::default' do
             end
           end
 
+          # don't include it if node['newrelic']['license'] not set
           it 'includes newrelic monitoring' do
             expect(chef_run).to include_recipe('newrelic::default')
           end


### PR DESCRIPTION
- .nil? check was allowing us to set NR license to false, causing https://github.com/escapestudios-cookbooks/newrelic/issues/178.
