### PR TITLE
install tmux on ubuntu only

### DIFF
--- a/recipes/rackops_rolebook.rb
+++ b/recipes/rackops_rolebook.rb
@@ -36,13 +36,13 @@ admin_packages = %w(
   zip
   lsof
   strace
-  tmux
   git
 )
 
 case node['platform_family']
 when 'debian'
   admin_packages.push('vim')
+  admin_packages.push('tmux')
   admin_packages.push('htop') # htop not available in cent/rhel w/o epel
   node.override['apt']['compile_time_update'] = true
   include_recipe 'apt'


### PR DESCRIPTION
rhel/centos requires epel, we're not assuming everyone is using epel.
